### PR TITLE
Fixed an accessibility issue with the student textarea.

### DIFF
--- a/front/src/pods/student/student.component.tsx
+++ b/front/src/pods/student/student.component.tsx
@@ -40,16 +40,17 @@ export const StudentComponent: React.FC<Props> = props => {
         <label className={innerClasses.label} htmlFor="session">
           Content
         </label>
-        <TextareaAutosize
-          role="log"
-          ref={textAreaRef}
-          id="session"
-          rowsMax={30}
-          rowsMin={30}
-          className={innerClasses.textarea}
-          value={log ?? ''}
-          readOnly={true}
-        />
+        <div role="log">
+          <TextareaAutosize
+            ref={textAreaRef}
+            id="session"
+            rowsMax={30}
+            rowsMin={30}
+            className={innerClasses.textarea}
+            value={log ?? ''}
+            readOnly={true}
+          />
+        </div>
         <FormControlLabel
           label="Disable AutoScroll"
           control={


### PR DESCRIPTION
Fixed an accessibility issue with the student textarea. Now, the text area is included into a div with role 'log'. IN that way, the textarea remains as a textbox for the accessibility API, and also the log role is kept in mind in order to speak the new content as it arrives.